### PR TITLE
Fix issues with "Edge Detection" example

### DIFF
--- a/Topics/Image Processing/EdgeDetection/EdgeDetection.pde
+++ b/Topics/Image Processing/EdgeDetection/EdgeDetection.pde
@@ -4,10 +4,17 @@
  * A high-pass filter sharpens an image. This program analyzes every
  * pixel in an image in relation to the neighboring pixels to sharpen 
  * the image. This example is currently not accurate in JavaScript mode.
+ *
+ * This kernel describes a "Laplacian Edge Detector".  It is effective,
+ * but sensitive to noise.  One common enhancement is to add a Gaussian
+ * blur to the source image first, as in
+ *   img.filter(BLUR);
+ * to reduce impact of noise on the output.  The combination is often called
+ * "Laplace of Gaussian", or "LoG" for short.
  */
 
 float[][] kernel = {{ -1, -1, -1}, 
-                    { -1,  9, -1}, 
+                    { -1,  8, -1}, 
                     { -1, -1, -1}};
                     
 PImage img;
@@ -26,7 +33,7 @@ void draw() {
   // Loop through every pixel in the image.
   for (int y = 1; y < img.height-1; y++) { // Skip top and bottom edges
     for (int x = 1; x < img.width-1; x++) { // Skip left and right edges
-      float sum = 0; // Kernel sum for this pixel
+      float sum = 127.5; // Kernel sum for this pixel
       for (int ky = -1; ky <= 1; ky++) {
         for (int kx = -1; kx <= 1; kx++) {
           // Calculate the adjacent pixel for this kernel point


### PR DESCRIPTION
There are two errors with this example.
* First, the kernel is incorrect.  The center pixel should be weighted at 8, not 9.
* Second, Laplacian output should be centered about the medium-brightness pixel value (0.5), and clamped to the 0 to 1.0 range.  The previous version began `sum` at 0, leading to negative values in the output...  Another way of presenting this would be to keep `sum` at 0, but add a `sum = abs(sum);` at line 48.

Fixed the errors and added a few more comments at the top.

EDIT: I should add that the previous version wasn't necessarily "wrong" - it was definitely a "high-pass filter" i.e. finding changes of intensity, as it says in the description - but that is a bit different than what people commonly call "edge detection".