### PR TITLE
Removed unnecessary `br` tags

### DIFF
--- a/Basics/Control/Conditionals1/Conditionals1.pde
+++ b/Basics/Control/Conditionals1/Conditionals1.pde
@@ -4,7 +4,7 @@
  * Conditions are like questions. 
  * They allow a program to decide to take one action if 
  * the answer to a question is "true" or to do another action
- * if the answer to the question is "false."<br /> 
+ * if the answer to the question is "false." 
  * The questions asked within a program are always logical
  * or relational statements. For example, if the variable 'i' is 
  * equal to zero then draw a line. 

--- a/Basics/Data/CharactersStrings/CharactersStrings.pde
+++ b/Basics/Data/CharactersStrings/CharactersStrings.pde
@@ -4,13 +4,13 @@
  * The character datatype, abbreviated as char, stores letters and 
  * symbols in the Unicode format, a coding system developed to support 
  * a variety of world languages. Characters are distinguished from other
- * symbols by putting them between single quotes ('P').<br />
- * <br />
+ * symbols by putting them between single quotes ('P').
+ * 
  * A string is a sequence of characters. A string is noted by surrounding 
  * a group of letters with double quotes ("Processing"). 
  * Chars and strings are most often used with the keyboard methods, 
- * to display text to the screen, and to load images or files.<br />
- * <br />
+ * to display text to the screen, and to load images or files.
+ * 
  * The String datatype must be capitalized because it is a complex datatype.
  * A String is actually a class with its own methods, some of which are
  * featured below. 

--- a/Topics/File IO/DirectoryList/DirectoryList.pde
+++ b/Topics/File IO/DirectoryList/DirectoryList.pde
@@ -2,11 +2,11 @@
  * Listing files in directories and subdirectories
  * by Daniel Shiffman.  
  * 
- * This example has three functions:<br />
- * 1) List the names of files in a directory<br />
- * 2) List the names along with metadata (size, lastModified)<br /> 
- *    of files in a directory<br />
- * 3) List the names along with metadata (size, lastModified)<br />
+ * This example has three functions:
+ * 1) List the names of files in a directory
+ * 2) List the names along with metadata (size, lastModified) 
+ *    of files in a directory
+ * 3) List the names along with metadata (size, lastModified)
  *    of files in a directory and all subdirectories (using recursion) 
  */
 

--- a/Topics/Geometry/ShapeTransform/ShapeTransform.pde
+++ b/Topics/Geometry/ShapeTransform/ShapeTransform.pde
@@ -6,10 +6,10 @@
  * between Cube, Pyramid, Cone and 
  * Cylinder 3D primitives.
  * 
- * Instructions:<br />
- * Up Arrow - increases points<br />
- * Down Arrow - decreases points<br />
- * 'p' key toggles between cube/pyramid<br />
+ * Instructions:
+ * Up Arrow - increases points
+ * Down Arrow - decreases points
+ * 'p' key toggles between cube/pyramid
  */
 
 int pts = 4; 

--- a/Topics/Geometry/Toroid/Toroid.pde
+++ b/Topics/Geometry/Toroid/Toroid.pde
@@ -5,17 +5,17 @@
  * Illustrates the geometric relationship between Toroid, Sphere, and Helix
  * 3D primitives, as well as lathing principal.
  * 
- * Instructions: <br />
- * UP arrow key pts++ <br />
- * DOWN arrow key pts-- <br />
- * LEFT arrow key segments-- <br />
- * RIGHT arrow key segments++ <br />
- * 'a' key toroid radius-- <br />
- * 's' key toroid radius++ <br />
- * 'z' key initial polygon radius-- <br />
- * 'x' key initial polygon radius++ <br />
- * 'w' key toggle wireframe/solid shading <br />
- * 'h' key toggle sphere/helix <br />
+ * Instructions: 
+ * UP arrow key pts++ 
+ * DOWN arrow key pts-- 
+ * LEFT arrow key segments-- 
+ * RIGHT arrow key segments++ 
+ * 'a' key toroid radius-- 
+ * 's' key toroid radius++ 
+ * 'z' key initial polygon radius-- 
+ * 'x' key initial polygon radius++ 
+ * 'w' key toggle wireframe/solid shading 
+ * 'h' key toggle sphere/helix 
  */
 
 int pts = 40; 


### PR DESCRIPTION
Fix #23

A small number of examples contained unnecessary `br` tags in the comments. This PR removes them.